### PR TITLE
modify integer type to uint16_t to avoid build error

### DIFF
--- a/nflog.go
+++ b/nflog.go
@@ -276,7 +276,7 @@ func (nflog *NfLog) makeGroup(group, size int) {
 	if *Verbose {
 		log.Printf("Binding this socket to group %d", group)
 	}
-	gh, err := C.nflog_bind_group(nflog.h, (C.u_int16_t)(group))
+	gh, err := C.nflog_bind_group(nflog.h, (C.uint16_t)(group))
 	if gh == nil || err != nil {
 		log.Fatalf("nflog_bind_group failed: %s", nflogError(err))
 	}


### PR DESCRIPTION
I'm getting an error:

./nflog.go:279: cannot use C.u_int16_t(group) (type C.u_int16_t) as type C.uint16_t in argument to _C2func_nflog_bind_group

which goes away with the suggested change (C.u_int16_t => C.uint16_t)

The signature of the C function in libnetfilter_log/libnetfilter_log.h is:

```
extern struct nflog_g_handle *nflog_bind_group(struct nflog_handle *h,
                         uint16_t num);
```
